### PR TITLE
Fix incorrect index being used when iterating over received DDS samples

### DIFF
--- a/vrxperience_bridge/include/vrxperience_bridge/sim_data_receiver.hpp
+++ b/vrxperience_bridge/include/vrxperience_bridge/sim_data_receiver.hpp
@@ -71,7 +71,7 @@ public:
       for (int i = 0; i < ret; i++) {
         if (infos[i].sample_state == DDS_SST_NOT_READ && infos[i].valid_data) {
           RosMsg rosMsg;
-          (*convert_)(*(reinterpret_cast<SimMsg *>(samples[0])), rosMsg);
+          (*convert_)(*(reinterpret_cast<SimMsg *>(samples[i])), rosMsg);
           ros_publisher_->publish(rosMsg);
         }
       }


### PR DESCRIPTION
Quick fix to replace incorrectly hard coded array index when iterating over received DDS samples.

This change will have no effect in practice as long as size of the sample buffer is kept at 1.