### PR TITLE
Fix memory leak in receiver.

### DIFF
--- a/vrxperience_bridge/include/vrxperience_bridge/sim_data_receiver.hpp
+++ b/vrxperience_bridge/include/vrxperience_bridge/sim_data_receiver.hpp
@@ -76,6 +76,10 @@ public:
         }
       }
     }
+
+    for (int i = 0; i < MAX_SAMPLES; i++) {
+      dds_free(samples[i]);
+    }
   }
 
 private:


### PR DESCRIPTION
Memory is allocated in the DDS receiver using `dds_alloc` but is not freed when no longer needed using `dds_free`. This results in a memory leak.