### PR TITLE
ROS2 Components and Clean-up

### DIFF
--- a/vrxperience_bridge/CMakeLists.txt
+++ b/vrxperience_bridge/CMakeLists.txt
@@ -30,10 +30,9 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 # find dependencies
-find_package(ament_cmake REQUIRED)
-find_package(rclcpp REQUIRED)
-find_package(vrxperience_msgs REQUIRED)
+find_package(ament_cmake_auto REQUIRED)
 find_package(CycloneDDS REQUIRED COMPONENTS idlc)
+ament_auto_find_build_dependencies()
 
 # generate code to handle custom DDS data types
 idlc_generate(IndyDS_RoadLinesPolynoms_lib "res/IndyDS_RoadLinesPolynoms.idl")
@@ -46,92 +45,79 @@ idlc_generate(IndyDS_CabToModelCorrective_lib "res/IndyDS_CabToModelCorrective.i
 idlc_generate(IndyDS_CabToSteeringCorrective_lib "res/IndyDS_CabToSteeringCorrective.idl")
 idlc_generate(DDS_Octets_lib "res/DDS_Octets.idl")
 
-include_directories(include)
-link_libraries(CycloneDDS::ddsc)
-
-add_executable(recv_road_lines_polynoms src/recv_road_lines_polynoms.cpp)
-ament_target_dependencies(recv_road_lines_polynoms rclcpp vrxperience_msgs)
-target_link_libraries(recv_road_lines_polynoms IndyDS_RoadLinesPolynoms_lib)
-install(
-  TARGETS recv_road_lines_polynoms
-  DESTINATION lib/${PROJECT_NAME}
+ament_auto_add_library(${PROJECT_NAME} SHARED
+  src/recv_dds_done.cpp
+  src/recv_gps.cpp
+  src/recv_laser_meter.cpp
+  src/recv_movable_targets.cpp
+  src/recv_movable_targets_bounding_boxes.cpp
+  src/recv_road_lines_polynoms.cpp
+  src/recv_vehicle_output.cpp
+  src/send_cab_to_model_corrective.cpp
+  src/send_cab_to_steering_corrective.cpp
+  src/send_dds_done_reply.cpp
+)
+target_link_libraries(${PROJECT_NAME}
+  CycloneDDS::ddsc
+  DDS_Octets_lib
+  IndyDS_CabToModelCorrective_lib
+  IndyDS_CabToSteeringCorrective_lib
+  IndyDS_GPS_lib
+  IndyDS_LaserMeter_lib
+  IndyDS_RoadLinesPolynoms_lib
+  IndyDS_SensorMovableTargetsBoundingBoxes_lib
+  IndyDS_SensorMovableTargets_lib
+  IndyDS_VehicleOutput_lib
 )
 
-add_executable(recv_movable_targets_bounding_boxes src/recv_movable_targets_bounding_boxes.cpp)
-ament_target_dependencies(recv_movable_targets_bounding_boxes rclcpp vrxperience_msgs)
-target_link_libraries(recv_movable_targets_bounding_boxes IndyDS_SensorMovableTargetsBoundingBoxes_lib)
-install(
-  TARGETS recv_movable_targets_bounding_boxes
-  DESTINATION lib/${PROJECT_NAME}
+rclcpp_components_register_node(${PROJECT_NAME}
+  PLUGIN "vrxperience_bridge::RecvDdsDone"
+  EXECUTABLE recv_dds_done
 )
 
-add_executable(recv_gps src/recv_gps.cpp)
-ament_target_dependencies(recv_gps rclcpp vrxperience_msgs)
-target_link_libraries(recv_gps IndyDS_GPS_lib)
-install(
-  TARGETS recv_gps
-  DESTINATION lib/${PROJECT_NAME}
+rclcpp_components_register_node(${PROJECT_NAME}
+  PLUGIN "vrxperience_bridge::RecvGps"
+  EXECUTABLE recv_gps
 )
 
-add_executable(recv_laser_meter src/recv_laser_meter.cpp)
-ament_target_dependencies(recv_laser_meter rclcpp vrxperience_msgs)
-target_link_libraries(recv_laser_meter IndyDS_LaserMeter_lib)
-install(
-  TARGETS recv_laser_meter
-  DESTINATION lib/${PROJECT_NAME}
+rclcpp_components_register_node(${PROJECT_NAME}
+  PLUGIN "vrxperience_bridge::RecvLaserMeter"
+  EXECUTABLE recv_laser_meter
 )
 
-add_executable(recv_movable_targets src/recv_movable_targets.cpp)
-ament_target_dependencies(recv_movable_targets rclcpp vrxperience_msgs)
-target_link_libraries(recv_movable_targets IndyDS_SensorMovableTargets_lib)
-install(
-  TARGETS recv_movable_targets
-  DESTINATION lib/${PROJECT_NAME}
+rclcpp_components_register_node(${PROJECT_NAME}
+  PLUGIN "vrxperience_bridge::RecvMovableTargets"
+  EXECUTABLE recv_movable_targets
 )
 
-add_executable(recv_vehicle_output src/recv_vehicle_output.cpp)
-ament_target_dependencies(recv_vehicle_output rclcpp vrxperience_msgs)
-target_link_libraries(recv_vehicle_output IndyDS_VehicleOutput_lib)
-install(
-  TARGETS recv_vehicle_output
-  DESTINATION lib/${PROJECT_NAME}
+rclcpp_components_register_node(${PROJECT_NAME}
+  PLUGIN "vrxperience_bridge::RecvMovableTargetsBoundingBoxes"
+  EXECUTABLE recv_movable_targets_bounding_boxes
 )
 
-add_executable(send_cab_to_model_corrective src/send_cab_to_model_corrective.cpp)
-ament_target_dependencies(send_cab_to_model_corrective rclcpp vrxperience_msgs)
-target_link_libraries(send_cab_to_model_corrective IndyDS_CabToModelCorrective_lib)
-install(
-  TARGETS send_cab_to_model_corrective
-  DESTINATION lib/${PROJECT_NAME}
+rclcpp_components_register_node(${PROJECT_NAME}
+  PLUGIN "vrxperience_bridge::RecvRoadLinesPolynoms"
+  EXECUTABLE recv_road_lines_polynoms
 )
 
-add_executable(send_cab_to_steering_corrective src/send_cab_to_steering_corrective.cpp)
-ament_target_dependencies(send_cab_to_steering_corrective rclcpp vrxperience_msgs)
-target_link_libraries(send_cab_to_steering_corrective IndyDS_CabToSteeringCorrective_lib)
-install(
-  TARGETS send_cab_to_steering_corrective
-  DESTINATION lib/${PROJECT_NAME}
+rclcpp_components_register_node(${PROJECT_NAME}
+  PLUGIN "vrxperience_bridge::RecvVehicleOutput"
+  EXECUTABLE recv_vehicle_output
 )
 
-add_executable(recv_dds_done src/recv_dds_done.cpp)
-ament_target_dependencies(recv_dds_done rclcpp vrxperience_msgs)
-target_link_libraries(recv_dds_done DDS_Octets_lib)
-install(
-  TARGETS recv_dds_done
-  DESTINATION lib/${PROJECT_NAME}
+rclcpp_components_register_node(${PROJECT_NAME}
+  PLUGIN "vrxperience_bridge::SendCabToModelCorrective"
+  EXECUTABLE send_cab_to_model_corrective
 )
 
-add_executable(send_dds_done_reply src/send_dds_done_reply.cpp)
-ament_target_dependencies(send_dds_done_reply rclcpp vrxperience_msgs)
-target_link_libraries(send_dds_done_reply DDS_Octets_lib)
-install(
-  TARGETS send_dds_done_reply
-  DESTINATION lib/${PROJECT_NAME}
+rclcpp_components_register_node(${PROJECT_NAME}
+  PLUGIN "vrxperience_bridge::SendCabToSteeringCorrective"
+  EXECUTABLE send_cab_to_steering_corrective
 )
 
-install(
-  DIRECTORY launch
-  DESTINATION share/${PROJECT_NAME}/
+rclcpp_components_register_node(${PROJECT_NAME}
+  PLUGIN "vrxperience_bridge::SendDdsDoneReply"
+  EXECUTABLE send_dds_done_reply
 )
 
 if(BUILD_TESTING)
@@ -140,4 +126,7 @@ if(BUILD_TESTING)
   ament_lint_auto_find_test_dependencies()
 endif()
 
-ament_package()
+ament_auto_package(
+  INSTALL_TO_SHARE
+    launch
+)

--- a/vrxperience_bridge/CMakeLists.txt
+++ b/vrxperience_bridge/CMakeLists.txt
@@ -71,52 +71,52 @@ target_link_libraries(${PROJECT_NAME}
 )
 
 rclcpp_components_register_node(${PROJECT_NAME}
-  PLUGIN "vrxperience_bridge::RecvDdsDone"
+  PLUGIN "vrxperience_bridge::DdsDoneReceiver"
   EXECUTABLE recv_dds_done
 )
 
 rclcpp_components_register_node(${PROJECT_NAME}
-  PLUGIN "vrxperience_bridge::RecvGps"
+  PLUGIN "vrxperience_bridge::GpsReceiver"
   EXECUTABLE recv_gps
 )
 
 rclcpp_components_register_node(${PROJECT_NAME}
-  PLUGIN "vrxperience_bridge::RecvLaserMeter"
+  PLUGIN "vrxperience_bridge::LaserMeterReceiver"
   EXECUTABLE recv_laser_meter
 )
 
 rclcpp_components_register_node(${PROJECT_NAME}
-  PLUGIN "vrxperience_bridge::RecvMovableTargets"
+  PLUGIN "vrxperience_bridge::MovableTargetsReceiver"
   EXECUTABLE recv_movable_targets
 )
 
 rclcpp_components_register_node(${PROJECT_NAME}
-  PLUGIN "vrxperience_bridge::RecvMovableTargetsBoundingBoxes"
+  PLUGIN "vrxperience_bridge::MovableTargetsBoundingBoxesReceiver"
   EXECUTABLE recv_movable_targets_bounding_boxes
 )
 
 rclcpp_components_register_node(${PROJECT_NAME}
-  PLUGIN "vrxperience_bridge::RecvRoadLinesPolynoms"
+  PLUGIN "vrxperience_bridge::RoadLinesPolynomsReceiver"
   EXECUTABLE recv_road_lines_polynoms
 )
 
 rclcpp_components_register_node(${PROJECT_NAME}
-  PLUGIN "vrxperience_bridge::RecvVehicleOutput"
+  PLUGIN "vrxperience_bridge::VehicleOutputReceiver"
   EXECUTABLE recv_vehicle_output
 )
 
 rclcpp_components_register_node(${PROJECT_NAME}
-  PLUGIN "vrxperience_bridge::SendCabToModelCorrective"
+  PLUGIN "vrxperience_bridge::CabToModelCorrectiveSender"
   EXECUTABLE send_cab_to_model_corrective
 )
 
 rclcpp_components_register_node(${PROJECT_NAME}
-  PLUGIN "vrxperience_bridge::SendCabToSteeringCorrective"
+  PLUGIN "vrxperience_bridge::CabToSteeringCorrectiveSender"
   EXECUTABLE send_cab_to_steering_corrective
 )
 
 rclcpp_components_register_node(${PROJECT_NAME}
-  PLUGIN "vrxperience_bridge::SendDdsDoneReply"
+  PLUGIN "vrxperience_bridge::DdsDoneReplySender"
   EXECUTABLE send_dds_done_reply
 )
 

--- a/vrxperience_bridge/include/vrxperience_bridge/sim_data_receiver.hpp
+++ b/vrxperience_bridge/include/vrxperience_bridge/sim_data_receiver.hpp
@@ -21,9 +21,6 @@
 #include <chrono>
 #include <string>
 
-#define IN
-#define OUT &
-
 // An array of one message (aka sample in DDS terms) will be used
 #define MAX_SAMPLES 1
 
@@ -41,7 +38,7 @@ template<class SimMsg, class RosMsg>
 class SimDataReceiver : public rclcpp::Node
 {
 public:
-  using ConvertFunc = std::function<void (SimMsg IN, RosMsg OUT)>;
+  using ConvertFunc = std::function<void (const SimMsg &, RosMsg &)>;
 
   SimDataReceiver(
     const std::string & ros_node_name,

--- a/vrxperience_bridge/include/vrxperience_bridge/sim_data_receiver.hpp
+++ b/vrxperience_bridge/include/vrxperience_bridge/sim_data_receiver.hpp
@@ -76,6 +76,10 @@ public:
         }
       }
     }
+
+    for (int i = 0; i < MAX_SAMPLES; i++) {
+      dds_free(samples[i]);
+    }
   }
 
 private:

--- a/vrxperience_bridge/include/vrxperience_bridge/sim_data_receiver.hpp
+++ b/vrxperience_bridge/include/vrxperience_bridge/sim_data_receiver.hpp
@@ -18,6 +18,7 @@
 #include <rclcpp/rclcpp.hpp>
 #include <dds/dds.h>
 
+#include <chrono>
 #include <string>
 
 #define IN
@@ -29,62 +30,105 @@
 namespace vrxperience_bridge
 {
 
+static constexpr int WORLD_FRAME = 0;
+static constexpr int VEHICLE_FRAME = 1;
+static constexpr int SENSOR_FRAME = 2;
+
+using std::placeholders::_1;
+using std::placeholders::_2;
+
 template<class SimMsg, class RosMsg>
 class SimDataReceiver : public rclcpp::Node
 {
 public:
-  typedef void (* sim2ros)(SimMsg IN, RosMsg OUT);
+  using ConvertFunc = std::function<void (SimMsg IN, RosMsg OUT)>;
 
-  SimDataReceiver(std::string ros_node_name, dds_topic_descriptor_t dds_topic_desc, sim2ros convert)
-  : Node(ros_node_name), dds_topic_desc_(dds_topic_desc), convert_(convert)
+  SimDataReceiver(
+    const std::string & ros_node_name,
+    const rclcpp::NodeOptions & options,
+    dds_topic_descriptor_t dds_topic_desc,
+    ConvertFunc convert
+  )
+  : Node(ros_node_name, options),
+    dds_topic_desc_(dds_topic_desc),
+    convert_(convert)
   {
     // Declare and read ROS parameters
     ros_topic_ = declare_parameter("ros_topic", "");
     dds_topic_ = declare_parameter("dds_topic", "");
     dds_domain_ = declare_parameter("dds_domain", 0);
-  }
 
-  void run()
-  {
     // Create DDS Domain Participant with appropriate Topic and Data Reader
-    auto participant = dds_create_participant(dds_domain_, nullptr, nullptr);
-    auto topic = dds_create_topic(
-      participant, &dds_topic_desc_,
+    participant_ = dds_create_participant(dds_domain_, nullptr, nullptr);
+
+    if (participant_ < 0) {
+      throw std::runtime_error{"Failed to create DDS participant."};
+    }
+
+    topic_ = dds_create_topic(
+      participant_, &dds_topic_desc_,
       dds_topic_.c_str(), nullptr, nullptr);
-    auto reader = dds_create_reader(participant, topic, nullptr, nullptr);
+
+    if (topic_ < 0) {
+      throw std::runtime_error{"Failed to create DDS topic."};
+    }
+
+    reader_ = dds_create_reader(participant_, topic_, nullptr, nullptr);
+
+    if (reader_ < 0) {
+      throw std::runtime_error{"Failed to create DDS reader."};
+    }
 
     // Create ROS Publisher
     ros_publisher_ = create_publisher<RosMsg>(ros_topic_, 1);
-
-    void * samples[MAX_SAMPLES];
-    dds_sample_info_t infos[MAX_SAMPLES];
 
     // Allocate memory to hold samples
     for (int i = 0; i < MAX_SAMPLES; i++) {
       samples[i] = dds_alloc(sizeof(SimMsg));
     }
 
-    while (rclcpp::ok()) {
-      auto ret = dds_read(reader, samples, infos, MAX_SAMPLES, MAX_SAMPLES);
+    timer_ = create_wall_timer(
+      std::chrono::milliseconds(10),
+      std::bind(&SimDataReceiver::read, this)
+    );
+  }
 
-      // Iterate through the samples and publish to ROS 2 if there are any new
-      for (int i = 0; i < ret; i++) {
-        if (infos[i].sample_state == DDS_SST_NOT_READ && infos[i].valid_data) {
-          RosMsg rosMsg;
-          (*convert_)(*(reinterpret_cast<SimMsg *>(samples[i])), rosMsg);
-          ros_publisher_->publish(rosMsg);
-        }
-      }
-    }
-
+  ~SimDataReceiver()
+  {
+    // Free allocated memory
     for (int i = 0; i < MAX_SAMPLES; i++) {
       dds_free(samples[i]);
     }
   }
 
+  void read()
+  {
+    auto ret = dds_read(reader_, samples, infos, MAX_SAMPLES, MAX_SAMPLES);
+
+    if (ret < 0) {
+      RCLCPP_ERROR(get_logger(), "Failed to read from DDS layer.");
+      return;
+    }
+
+    // Iterate through the samples and publish to ROS 2 if there are any new
+    for (int i = 0; i < ret; i++) {
+      if (infos[i].sample_state == DDS_SST_NOT_READ && infos[i].valid_data) {
+        RosMsg rosMsg;
+        convert_(*(reinterpret_cast<SimMsg *>(samples[i])), rosMsg);
+        ros_publisher_->publish(rosMsg);
+      }
+    }
+  }
+
 private:
+  dds_entity_t participant_;
+  dds_entity_t topic_;
+  dds_entity_t reader_;
+  void * samples[MAX_SAMPLES];
+  dds_sample_info_t infos[MAX_SAMPLES];
   dds_topic_descriptor_t dds_topic_desc_;
-  sim2ros convert_;
+  ConvertFunc convert_;
+  rclcpp::TimerBase::SharedPtr timer_;
 
   std::string ros_topic_;
   std::string dds_topic_;

--- a/vrxperience_bridge/include/vrxperience_bridge/sim_data_sender.hpp
+++ b/vrxperience_bridge/include/vrxperience_bridge/sim_data_sender.hpp
@@ -20,9 +20,6 @@
 
 #include <string>
 
-#define IN
-#define OUT &
-
 namespace vrxperience_bridge
 {
 
@@ -33,7 +30,7 @@ template<class RosMsg, class SimMsg>
 class SimDataSender : public rclcpp::Node
 {
 public:
-  using ConvertFunc = std::function<void (RosMsg IN, SimMsg OUT)>;
+  using ConvertFunc = std::function<void (const RosMsg &, SimMsg &)>;
 
   SimDataSender(
     const std::string & ros_node_name,

--- a/vrxperience_bridge/include/vrxperience_bridge/sim_data_sender.hpp
+++ b/vrxperience_bridge/include/vrxperience_bridge/sim_data_sender.hpp
@@ -26,14 +26,24 @@
 namespace vrxperience_bridge
 {
 
+using std::placeholders::_1;
+using std::placeholders::_2;
+
 template<class RosMsg, class SimMsg>
 class SimDataSender : public rclcpp::Node
 {
 public:
-  typedef void (* ros2sim)(RosMsg IN, SimMsg OUT);
+  using ConvertFunc = std::function<void (RosMsg IN, SimMsg OUT)>;
 
-  SimDataSender(std::string ros_node_name, dds_topic_descriptor_t dds_topic_desc, ros2sim convert)
-  : Node(ros_node_name), dds_topic_desc_(dds_topic_desc), convert_(convert)
+  SimDataSender(
+    const std::string & ros_node_name,
+    const rclcpp::NodeOptions & options,
+    dds_topic_descriptor_t dds_topic_desc,
+    ConvertFunc convert
+  )
+  : Node(ros_node_name, options),
+    dds_topic_desc_(dds_topic_desc),
+    convert_(convert)
   {
     // Declare  and read ROS parameters
     ros_topic_ = declare_parameter("ros_topic", "");
@@ -57,12 +67,12 @@ private:
   void topicCallback(const typename RosMsg::SharedPtr rosMsg)
   {
     SimMsg simMsg;
-    (*convert_)(*rosMsg, simMsg);
+    convert_(*rosMsg, simMsg);
     dds_write(sim_writer_, &simMsg);
   }
 
   dds_topic_descriptor_t dds_topic_desc_;
-  ros2sim convert_;
+  ConvertFunc convert_;
 
   std::string ros_topic_;
   std::string dds_topic_;

--- a/vrxperience_bridge/package.xml
+++ b/vrxperience_bridge/package.xml
@@ -8,12 +8,14 @@
   <license>Apache 2.0</license>
   <url type="repository">https://github.com/autowarefoundation/ansys-vrxperience-ros2</url>
   <author email="gotlib.adam+dev@gmail.com">Adam Gotlib</author>
+  <author email="josh.whitley@autoware.org">Josh Whitley</author>
   <author>Trent Weiss</author>
 
-  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
   <depend>launch_xml</depend>
   <depend>rclcpp</depend>
+  <depend>rclcpp_components</depend>
   <depend>tf2</depend>
   <depend>vrxperience_msgs</depend>
   <depend>cyclonedds</depend>

--- a/vrxperience_bridge/src/recv_dds_done.cpp
+++ b/vrxperience_bridge/src/recv_dds_done.cpp
@@ -32,7 +32,7 @@ public:
   {
   }
 
-  void convert(DDS_Octets IN simMsg, std_msgs::msg::ByteMultiArray OUT rosMsg)
+  void convert(const DDS_Octets & simMsg, std_msgs::msg::ByteMultiArray & rosMsg)
   {
     for (uint32_t i = 0; i < simMsg.value._length; i++) {
       rosMsg.data.push_back(simMsg.value._buffer[i]);

--- a/vrxperience_bridge/src/recv_dds_done.cpp
+++ b/vrxperience_bridge/src/recv_dds_done.cpp
@@ -16,18 +16,31 @@
 #include "std_msgs/msg/byte_multi_array.hpp"
 #include "DDS_Octets.h"
 
-using vrxperience_bridge::SimDataReceiver;
-typedef SimDataReceiver<DDS_Octets, std_msgs::msg::ByteMultiArray> DDSDoneReceiver;
+namespace vrxperience_bridge
+{
 
-void convert(DDS_Octets IN simMsg, std_msgs::msg::ByteMultiArray OUT rosMsg)
+class DdsDoneReceiver
+  : public SimDataReceiver<DDS_Octets, std_msgs::msg::ByteMultiArray>
 {
-  for (uint32_t i = 0; i < simMsg.value._length; i++) {
-    rosMsg.data.push_back(simMsg.value._buffer[i]);
+public:
+  explicit DdsDoneReceiver(const rclcpp::NodeOptions & options)
+  : SimDataReceiver(
+      "recv_dds_done",
+      options,
+      DDS_Octets_desc,
+      std::bind(&DdsDoneReceiver::convert, this, _1, _2))
+  {
   }
-}
-int main(int argc, char * argv[])
-{
-  rclcpp::init(argc, argv);
-  DDSDoneReceiver receiver("recv_dds_done", DDS_Octets_desc, &convert);
-  receiver.run();
-}
+
+  void convert(DDS_Octets IN simMsg, std_msgs::msg::ByteMultiArray OUT rosMsg)
+  {
+    for (uint32_t i = 0; i < simMsg.value._length; i++) {
+      rosMsg.data.push_back(simMsg.value._buffer[i]);
+    }
+  }
+};  // class DdsDoneReceiver
+
+}  // namespace vrxperience_bridge
+
+#include <rclcpp_components/register_node_macro.hpp>  // NOLINT
+RCLCPP_COMPONENTS_REGISTER_NODE(vrxperience_bridge::DdsDoneReceiver)

--- a/vrxperience_bridge/src/recv_gps.cpp
+++ b/vrxperience_bridge/src/recv_gps.cpp
@@ -33,7 +33,7 @@ public:
   {
   }
 
-  void convert(IndyDS_GPS IN simMsg, vrxperience_msgs::msg::GPS OUT rosMsg)
+  void convert(const IndyDS_GPS & simMsg, vrxperience_msgs::msg::GPS & rosMsg)
   {
     rosMsg.header.stamp.sec = static_cast<int>(simMsg.lastUpdate);
     rosMsg.header.stamp.nanosec =

--- a/vrxperience_bridge/src/recv_gps.cpp
+++ b/vrxperience_bridge/src/recv_gps.cpp
@@ -16,27 +16,40 @@
 #include "vrxperience_msgs/msg/gps.hpp"
 #include "IndyDS_GPS.h"
 
-using vrxperience_bridge::SimDataReceiver;
-typedef SimDataReceiver<IndyDS_GPS, vrxperience_msgs::msg::GPS> GPSReceiver;
-
-void convert(IndyDS_GPS IN simMsg, vrxperience_msgs::msg::GPS OUT rosMsg)
+namespace vrxperience_bridge
 {
-  rosMsg.header.stamp.sec = static_cast<int>(simMsg.lastUpdate);
-  rosMsg.header.stamp.nanosec =
-    (static_cast<int>(simMsg.lastUpdate * 1e9)) % static_cast<int>(1e9);
 
-  rosMsg.global_id = simMsg.globalId;
-  rosMsg.ego_vehicle_id = simMsg.vhlId;
-  rosMsg.sensor_id = simMsg.sensorId;
-  rosMsg.latitude = simMsg.latitude;
-  rosMsg.longitude = simMsg.longitude;
-  rosMsg.satellites = simMsg.satellites;
-  rosMsg.hdop = simMsg.hdop;
-}
-
-int main(int argc, char * argv[])
+class GpsReceiver
+  : public SimDataReceiver<IndyDS_GPS, vrxperience_msgs::msg::GPS>
 {
-  rclcpp::init(argc, argv);
-  GPSReceiver receiver("recv_gps", IndyDS_GPS_desc, &convert);
-  receiver.run();
-}
+public:
+  explicit GpsReceiver(const rclcpp::NodeOptions & options)
+  : SimDataReceiver(
+      "recv_gps",
+      options,
+      IndyDS_GPS_desc,
+      std::bind(&GpsReceiver::convert, this, _1, _2)
+  )
+  {
+  }
+
+  void convert(IndyDS_GPS IN simMsg, vrxperience_msgs::msg::GPS OUT rosMsg)
+  {
+    rosMsg.header.stamp.sec = static_cast<int>(simMsg.lastUpdate);
+    rosMsg.header.stamp.nanosec =
+      (static_cast<int>(simMsg.lastUpdate * 1e9)) % static_cast<int>(1e9);
+
+    rosMsg.global_id = simMsg.globalId;
+    rosMsg.ego_vehicle_id = simMsg.vhlId;
+    rosMsg.sensor_id = simMsg.sensorId;
+    rosMsg.latitude = simMsg.latitude;
+    rosMsg.longitude = simMsg.longitude;
+    rosMsg.satellites = simMsg.satellites;
+    rosMsg.hdop = simMsg.hdop;
+  }
+};  // class GpsReceiver
+
+}  // namespace vrxperience_bridge
+
+#include <rclcpp_components/register_node_macro.hpp>  // NOLINT
+RCLCPP_COMPONENTS_REGISTER_NODE(vrxperience_bridge::GpsReceiver)

--- a/vrxperience_bridge/src/recv_laser_meter.cpp
+++ b/vrxperience_bridge/src/recv_laser_meter.cpp
@@ -12,47 +12,63 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <string>
+
 #include "vrxperience_bridge/sim_data_receiver.hpp"
 #include "vrxperience_msgs/msg/laser_meter.hpp"
 #include "IndyDS_LaserMeter.h"
 
-using vrxperience_bridge::SimDataReceiver;
-typedef SimDataReceiver<IndyDS_LaserMeter, vrxperience_msgs::msg::LaserMeter> LaserMeterReceiver;
-
-std::string sensor_frame;  // NOLINT
-
-void convert(IndyDS_LaserMeter IN simMsg, vrxperience_msgs::msg::LaserMeter OUT rosMsg)
+namespace vrxperience_bridge
 {
-  rosMsg.header.stamp.sec = static_cast<int>(simMsg.lastUpdate);
-  rosMsg.header.stamp.nanosec =
-    (static_cast<int>(simMsg.lastUpdate * 1e9)) % (static_cast<int>(1e9));
-  rosMsg.header.frame_id = sensor_frame;
 
-  rosMsg.global_id = simMsg.globalId;
-  rosMsg.ego_vehicle_id = simMsg.vhlId;
-  rosMsg.sensor_id = simMsg.sensorId;
-  rosMsg.nearest_point = simMsg.nearestPoint;
-
-  for (uint32_t i = 0; i < simMsg.resultArray._length; i++) {
-    auto simLaserMeterPointMsg = simMsg.resultArray._buffer[i];
-    vrxperience_msgs::msg::LaserMeterPoint rosLaserMeterPointMsg;
-
-    rosLaserMeterPointMsg.hit = simLaserMeterPointMsg.hit;
-    rosLaserMeterPointMsg.h_angle = simLaserMeterPointMsg.Hangle;
-    rosLaserMeterPointMsg.v_angle = simLaserMeterPointMsg.Vangle;
-    rosLaserMeterPointMsg.intersection_point.x = simLaserMeterPointMsg.relposx;
-    rosLaserMeterPointMsg.intersection_point.y = simLaserMeterPointMsg.relposy;
-    rosLaserMeterPointMsg.intersection_point.z = simLaserMeterPointMsg.relposz;
-    rosLaserMeterPointMsg.distance = simLaserMeterPointMsg.distance;
-
-    rosMsg.results.push_back(rosLaserMeterPointMsg);
+class LaserMeterReceiver
+  : public SimDataReceiver<IndyDS_LaserMeter, vrxperience_msgs::msg::LaserMeter>
+{
+public:
+  explicit LaserMeterReceiver(const rclcpp::NodeOptions & options)
+  : SimDataReceiver(
+      "recv_movable_targets",
+      options,
+      IndyDS_LaserMeter_desc,
+      std::bind(&LaserMeterReceiver::convert, this, _1, _2)
+  )
+  {
+    sensor_frame_ = declare_parameter("sensor_frame", "");
   }
-}
 
-int main(int argc, char * argv[])
-{
-  rclcpp::init(argc, argv);
-  LaserMeterReceiver receiver("recv_movable_targets", IndyDS_LaserMeter_desc, &convert);
-  sensor_frame = receiver.declare_parameter("sensor_frame", "");
-  receiver.run();
-}
+  void convert(IndyDS_LaserMeter IN simMsg, vrxperience_msgs::msg::LaserMeter OUT rosMsg)
+  {
+    rosMsg.header.stamp.sec = static_cast<int>(simMsg.lastUpdate);
+    rosMsg.header.stamp.nanosec =
+      (static_cast<int>(simMsg.lastUpdate * 1e9)) % (static_cast<int>(1e9));
+    rosMsg.header.frame_id = sensor_frame_;
+
+    rosMsg.global_id = simMsg.globalId;
+    rosMsg.ego_vehicle_id = simMsg.vhlId;
+    rosMsg.sensor_id = simMsg.sensorId;
+    rosMsg.nearest_point = simMsg.nearestPoint;
+
+    for (uint32_t i = 0; i < simMsg.resultArray._length; i++) {
+      auto simLaserMeterPointMsg = simMsg.resultArray._buffer[i];
+      vrxperience_msgs::msg::LaserMeterPoint rosLaserMeterPointMsg;
+
+      rosLaserMeterPointMsg.hit = simLaserMeterPointMsg.hit;
+      rosLaserMeterPointMsg.h_angle = simLaserMeterPointMsg.Hangle;
+      rosLaserMeterPointMsg.v_angle = simLaserMeterPointMsg.Vangle;
+      rosLaserMeterPointMsg.intersection_point.x = simLaserMeterPointMsg.relposx;
+      rosLaserMeterPointMsg.intersection_point.y = simLaserMeterPointMsg.relposy;
+      rosLaserMeterPointMsg.intersection_point.z = simLaserMeterPointMsg.relposz;
+      rosLaserMeterPointMsg.distance = simLaserMeterPointMsg.distance;
+
+      rosMsg.results.push_back(rosLaserMeterPointMsg);
+    }
+  }
+
+private:
+  std::string sensor_frame_;
+};  // class LaserMeterReceiver
+
+}  // namespace vrxperience_bridge
+
+#include <rclcpp_components/register_node_macro.hpp>  // NOLINT
+RCLCPP_COMPONENTS_REGISTER_NODE(vrxperience_bridge::LaserMeterReceiver)

--- a/vrxperience_bridge/src/recv_laser_meter.cpp
+++ b/vrxperience_bridge/src/recv_laser_meter.cpp
@@ -36,7 +36,7 @@ public:
     sensor_frame_ = declare_parameter("sensor_frame", "");
   }
 
-  void convert(IndyDS_LaserMeter IN simMsg, vrxperience_msgs::msg::LaserMeter OUT rosMsg)
+  void convert(const IndyDS_LaserMeter & simMsg, vrxperience_msgs::msg::LaserMeter & rosMsg)
   {
     rosMsg.header.stamp.sec = static_cast<int>(simMsg.lastUpdate);
     rosMsg.header.stamp.nanosec =

--- a/vrxperience_bridge/src/recv_movable_targets.cpp
+++ b/vrxperience_bridge/src/recv_movable_targets.cpp
@@ -42,8 +42,8 @@ public:
   }
 
   void convert(
-    IndyDS_SensorMovableTargets IN simMsg,
-    vrxperience_msgs::msg::MovableTargets OUT rosMsg)
+    const IndyDS_SensorMovableTargets & simMsg,
+    vrxperience_msgs::msg::MovableTargets & rosMsg)
   {
     rosMsg.header.stamp.sec = static_cast<int>(simMsg.timeOfUpdate);
     rosMsg.header.stamp.nanosec =

--- a/vrxperience_bridge/src/recv_movable_targets.cpp
+++ b/vrxperience_bridge/src/recv_movable_targets.cpp
@@ -20,111 +20,120 @@
 #include "vrxperience_msgs/msg/movable_targets.hpp"
 #include "IndyDS_SensorMovableTargets.h"
 
-using vrxperience_bridge::SimDataReceiver;
-typedef SimDataReceiver<IndyDS_SensorMovableTargets,
-    vrxperience_msgs::msg::MovableTargets> MovableTargetsReceiver;
-
-const int WORLD_FRAME = 0;
-const int VEHICLE_FRAME = 1;
-const int SENSOR_FRAME = 2;
-
-std::string world_frame;  // NOLINT
-std::string vehicle_frame;  // NOLINT
-std::string sensor_frame;  // NOLINT
-
-void convert(
-  IndyDS_SensorMovableTargets IN simMsg,
-  vrxperience_msgs::msg::MovableTargets OUT rosMsg)
+namespace vrxperience_bridge
 {
-  rosMsg.header.stamp.sec = static_cast<int>(simMsg.timeOfUpdate);
-  rosMsg.header.stamp.nanosec =
-    (static_cast<int>(simMsg.timeOfUpdate * 1e9)) % (static_cast<int>(1e9));
 
-  rosMsg.global_id = simMsg.globalId;
-  rosMsg.ego_vehicle_id = simMsg.egoVhlId;
-  rosMsg.nearest_target = simMsg.nearestTarget;
+class MovableTargetsReceiver
+  : public SimDataReceiver<IndyDS_SensorMovableTargets,
+    vrxperience_msgs::msg::MovableTargets>
+{
+public:
+  explicit MovableTargetsReceiver(const rclcpp::NodeOptions & options)
+  : SimDataReceiver(
+      "recv_movable_targets",
+      options,
+      IndyDS_SensorMovableTargets_desc,
+      std::bind(&MovableTargetsReceiver::convert, this, _1, _2)
+  )
+  {
+    world_frame_ = declare_parameter("world_frame", "world");
+    vehicle_frame_ = declare_parameter("vehicle_frame", "base_link");
+    sensor_frame_ = declare_parameter("sensor_frame", "");
+  }
 
-  for (uint32_t i = 0; i < simMsg.targetsArray._length; i++) {
-    auto simMovableTargetMsg = simMsg.targetsArray._buffer[i];
-    vrxperience_msgs::msg::MovableTarget rosMovableTargetMsg;
-
-    rosMovableTargetMsg.header.stamp.sec = static_cast<int>(simMsg.timeOfUpdate);
-    rosMovableTargetMsg.header.stamp.nanosec =
+  void convert(
+    IndyDS_SensorMovableTargets IN simMsg,
+    vrxperience_msgs::msg::MovableTargets OUT rosMsg)
+  {
+    rosMsg.header.stamp.sec = static_cast<int>(simMsg.timeOfUpdate);
+    rosMsg.header.stamp.nanosec =
       (static_cast<int>(simMsg.timeOfUpdate * 1e9)) % (static_cast<int>(1e9));
 
-    switch (simMovableTargetMsg.referenceFrame) {
-      case WORLD_FRAME:
-        rosMovableTargetMsg.header.frame_id = world_frame;
-        break;
-      case VEHICLE_FRAME:
-        rosMovableTargetMsg.header.frame_id = vehicle_frame;
-        break;
-      case SENSOR_FRAME:
-        rosMovableTargetMsg.header.frame_id = sensor_frame;
-        break;
+    rosMsg.global_id = simMsg.globalId;
+    rosMsg.ego_vehicle_id = simMsg.egoVhlId;
+    rosMsg.nearest_target = simMsg.nearestTarget;
+
+    for (uint32_t i = 0; i < simMsg.targetsArray._length; i++) {
+      auto simMovableTargetMsg = simMsg.targetsArray._buffer[i];
+      vrxperience_msgs::msg::MovableTarget rosMovableTargetMsg;
+
+      rosMovableTargetMsg.header.stamp.sec = static_cast<int>(simMsg.timeOfUpdate);
+      rosMovableTargetMsg.header.stamp.nanosec =
+        (static_cast<int>(simMsg.timeOfUpdate * 1e9)) % (static_cast<int>(1e9));
+
+      switch (simMovableTargetMsg.referenceFrame) {
+        case WORLD_FRAME:
+          rosMovableTargetMsg.header.frame_id = world_frame_;
+          break;
+        case VEHICLE_FRAME:
+          rosMovableTargetMsg.header.frame_id = vehicle_frame_;
+          break;
+        case SENSOR_FRAME:
+          rosMovableTargetMsg.header.frame_id = sensor_frame_;
+          break;
+      }
+
+      rosMovableTargetMsg.id = simMovableTargetMsg.id;
+      rosMovableTargetMsg.scaner_id = simMovableTargetMsg.scanerId;
+      rosMovableTargetMsg.detection_status = simMovableTargetMsg.detectionStatus;
+      rosMovableTargetMsg.type = simMovableTargetMsg.type_;
+      rosMovableTargetMsg.beam_index = simMovableTargetMsg.beamIndex;
+      rosMovableTargetMsg.existence_time = simMovableTargetMsg.existenceTime;
+      rosMovableTargetMsg.anchor_point = simMovableTargetMsg.anchorPoint;
+      rosMovableTargetMsg.pose.position.x = simMovableTargetMsg.posXInChosenRef;
+      rosMovableTargetMsg.pose.position.y = simMovableTargetMsg.posYInChosenRef;
+      rosMovableTargetMsg.pose.position.z = simMovableTargetMsg.posZInChosenRef;
+
+      // Convert Euler angles to quaternion
+      tf2::Quaternion q;
+      q.setRPY(
+        simMovableTargetMsg.posRollInChosenRef,
+        simMovableTargetMsg.posPitchInChosenRef,
+        simMovableTargetMsg.posHeadingInChosenRef);
+      rosMovableTargetMsg.pose.orientation.x = q.getX();
+      rosMovableTargetMsg.pose.orientation.y = q.getY();
+      rosMovableTargetMsg.pose.orientation.z = q.getZ();
+      rosMovableTargetMsg.pose.orientation.w = q.getW();
+
+      rosMovableTargetMsg.distance_to_collision = simMovableTargetMsg.distanceToCollision;
+      rosMovableTargetMsg.azimuth_in_sensor = simMovableTargetMsg.azimuthInSensor;
+      rosMovableTargetMsg.elevation_in_sensor = simMovableTargetMsg.elevationInSensor;
+      rosMovableTargetMsg.azimuth_in_vehicle = simMovableTargetMsg.azimuthInVehicle;
+      rosMovableTargetMsg.elevation_in_vehicle = simMovableTargetMsg.elevationInVehicle;
+      rosMovableTargetMsg.absolute_speed.x = simMovableTargetMsg.absoluteSpeedX;
+      rosMovableTargetMsg.absolute_speed.y = simMovableTargetMsg.absoluteSpeedY;
+      rosMovableTargetMsg.absolute_speed.z = simMovableTargetMsg.absoluteSpeedZ;
+      rosMovableTargetMsg.absolute_angular_speed.x = simMovableTargetMsg.absoluteAngularSpeedR;
+      rosMovableTargetMsg.absolute_angular_speed.y = simMovableTargetMsg.absoluteAngularSpeedP;
+      rosMovableTargetMsg.absolute_angular_speed.z = simMovableTargetMsg.absoluteAngularSpeedH;
+      rosMovableTargetMsg.relative_speed.x = simMovableTargetMsg.relativeSpeedX;
+      rosMovableTargetMsg.relative_speed.y = simMovableTargetMsg.relativeSpeedY;
+      rosMovableTargetMsg.relative_speed.z = simMovableTargetMsg.relativeSpeedZ;
+      rosMovableTargetMsg.relative_angular_speed.x = simMovableTargetMsg.relativeAngularSpeedR;
+      rosMovableTargetMsg.relative_angular_speed.y = simMovableTargetMsg.relativeAngularSpeedP;
+      rosMovableTargetMsg.relative_angular_speed.z = simMovableTargetMsg.relativeAngularSpeedH;
+      rosMovableTargetMsg.absolute_accel.x = simMovableTargetMsg.absoluteAccelX;
+      rosMovableTargetMsg.absolute_accel.y = simMovableTargetMsg.absoluteAccelY;
+      rosMovableTargetMsg.absolute_accel.z = simMovableTargetMsg.absoluteAccelZ;
+      rosMovableTargetMsg.relative_accel.x = simMovableTargetMsg.relativeAccelX;
+      rosMovableTargetMsg.relative_accel.y = simMovableTargetMsg.relativeAccelY;
+      rosMovableTargetMsg.relative_accel.z = simMovableTargetMsg.relativeAccelZ;
+      rosMovableTargetMsg.length = simMovableTargetMsg.length;
+      rosMovableTargetMsg.width = simMovableTargetMsg.width;
+      rosMovableTargetMsg.height = simMovableTargetMsg.height;
+      rosMovableTargetMsg.visibility = simMovableTargetMsg.visibility;
+
+      rosMsg.targets.push_back(rosMovableTargetMsg);
     }
-
-    rosMovableTargetMsg.id = simMovableTargetMsg.id;
-    rosMovableTargetMsg.scaner_id = simMovableTargetMsg.scanerId;
-    rosMovableTargetMsg.detection_status = simMovableTargetMsg.detectionStatus;
-    rosMovableTargetMsg.type = simMovableTargetMsg.type_;
-    rosMovableTargetMsg.beam_index = simMovableTargetMsg.beamIndex;
-    rosMovableTargetMsg.existence_time = simMovableTargetMsg.existenceTime;
-    rosMovableTargetMsg.anchor_point = simMovableTargetMsg.anchorPoint;
-    rosMovableTargetMsg.pose.position.x = simMovableTargetMsg.posXInChosenRef;
-    rosMovableTargetMsg.pose.position.y = simMovableTargetMsg.posYInChosenRef;
-    rosMovableTargetMsg.pose.position.z = simMovableTargetMsg.posZInChosenRef;
-
-    // Convert Euler angles to quaternion
-    tf2::Quaternion q;
-    q.setRPY(
-      simMovableTargetMsg.posRollInChosenRef,
-      simMovableTargetMsg.posPitchInChosenRef,
-      simMovableTargetMsg.posHeadingInChosenRef);
-    rosMovableTargetMsg.pose.orientation.x = q.getX();
-    rosMovableTargetMsg.pose.orientation.y = q.getY();
-    rosMovableTargetMsg.pose.orientation.z = q.getZ();
-    rosMovableTargetMsg.pose.orientation.w = q.getW();
-
-    rosMovableTargetMsg.distance_to_collision = simMovableTargetMsg.distanceToCollision;
-    rosMovableTargetMsg.azimuth_in_sensor = simMovableTargetMsg.azimuthInSensor;
-    rosMovableTargetMsg.elevation_in_sensor = simMovableTargetMsg.elevationInSensor;
-    rosMovableTargetMsg.azimuth_in_vehicle = simMovableTargetMsg.azimuthInVehicle;
-    rosMovableTargetMsg.elevation_in_vehicle = simMovableTargetMsg.elevationInVehicle;
-    rosMovableTargetMsg.absolute_speed.x = simMovableTargetMsg.absoluteSpeedX;
-    rosMovableTargetMsg.absolute_speed.y = simMovableTargetMsg.absoluteSpeedY;
-    rosMovableTargetMsg.absolute_speed.z = simMovableTargetMsg.absoluteSpeedZ;
-    rosMovableTargetMsg.absolute_angular_speed.x = simMovableTargetMsg.absoluteAngularSpeedR;
-    rosMovableTargetMsg.absolute_angular_speed.y = simMovableTargetMsg.absoluteAngularSpeedP;
-    rosMovableTargetMsg.absolute_angular_speed.z = simMovableTargetMsg.absoluteAngularSpeedH;
-    rosMovableTargetMsg.relative_speed.x = simMovableTargetMsg.relativeSpeedX;
-    rosMovableTargetMsg.relative_speed.y = simMovableTargetMsg.relativeSpeedY;
-    rosMovableTargetMsg.relative_speed.z = simMovableTargetMsg.relativeSpeedZ;
-    rosMovableTargetMsg.relative_angular_speed.x = simMovableTargetMsg.relativeAngularSpeedR;
-    rosMovableTargetMsg.relative_angular_speed.y = simMovableTargetMsg.relativeAngularSpeedP;
-    rosMovableTargetMsg.relative_angular_speed.z = simMovableTargetMsg.relativeAngularSpeedH;
-    rosMovableTargetMsg.absolute_accel.x = simMovableTargetMsg.absoluteAccelX;
-    rosMovableTargetMsg.absolute_accel.y = simMovableTargetMsg.absoluteAccelY;
-    rosMovableTargetMsg.absolute_accel.z = simMovableTargetMsg.absoluteAccelZ;
-    rosMovableTargetMsg.relative_accel.x = simMovableTargetMsg.relativeAccelX;
-    rosMovableTargetMsg.relative_accel.y = simMovableTargetMsg.relativeAccelY;
-    rosMovableTargetMsg.relative_accel.z = simMovableTargetMsg.relativeAccelZ;
-    rosMovableTargetMsg.length = simMovableTargetMsg.length;
-    rosMovableTargetMsg.width = simMovableTargetMsg.width;
-    rosMovableTargetMsg.height = simMovableTargetMsg.height;
-    rosMovableTargetMsg.visibility = simMovableTargetMsg.visibility;
-
-    rosMsg.targets.push_back(rosMovableTargetMsg);
   }
-}
 
-int main(int argc, char * argv[])
-{
-  rclcpp::init(argc, argv);
-  MovableTargetsReceiver receiver("recv_movable_targets", IndyDS_SensorMovableTargets_desc,
-    &convert);
-  world_frame = receiver.declare_parameter("world_frame", "world");
-  vehicle_frame = receiver.declare_parameter("vehicle_frame", "base_link");
-  sensor_frame = receiver.declare_parameter("sensor_frame", "");
-  receiver.run();
-}
+private:
+  std::string world_frame_;
+  std::string vehicle_frame_;
+  std::string sensor_frame_;
+};  // class MovableTargetsReceiver
+
+}  // namespace vrxperience_bridge
+
+#include <rclcpp_components/register_node_macro.hpp>  // NOLINT
+RCLCPP_COMPONENTS_REGISTER_NODE(vrxperience_bridge::MovableTargetsReceiver)

--- a/vrxperience_bridge/src/recv_movable_targets_bounding_boxes.cpp
+++ b/vrxperience_bridge/src/recv_movable_targets_bounding_boxes.cpp
@@ -18,97 +18,104 @@
 #include "vrxperience_msgs/msg/movable_targets_bounding_boxes.hpp"
 #include "IndyDS_SensorMovableTargetsBoundingBoxes.h"
 
-using vrxperience_bridge::SimDataReceiver;
-typedef SimDataReceiver<IndyDS_SensorMovableTargetsBoundingBoxes,
-    vrxperience_msgs::msg::MovableTargetsBoundingBoxes> MovableTargetsBoundingBoxesReceiver;
-
-const int WORLD_FRAME = 0;
-const int VEHICLE_FRAME = 1;
-const int SENSOR_FRAME = 2;
-
-std::string world_frame;  // NOLINT
-std::string vehicle_frame;  // NOLINT
-std::string sensor_frame;  // NOLINT
-
-void convert(
-  IndyDS_SensorMovableTargetsBoundingBoxes IN simMsg,
-  vrxperience_msgs::msg::MovableTargetsBoundingBoxes OUT rosMsg)
+namespace vrxperience_bridge
 {
-  rosMsg.header.stamp.sec = static_cast<int>(simMsg.timeOfUpdate);
-  rosMsg.header.stamp.nanosec =
-    (static_cast<int>(simMsg.timeOfUpdate * 1e9)) % (static_cast<int>(1e9));
-  rosMsg.header.frame_id = sensor_frame;
 
-  rosMsg.global_id = simMsg.globalId;
-  rosMsg.ego_vehicle_id = simMsg.vhlId;
-
-  for (uint32_t i = 0; i < simMsg.boundingBoxesArray._length; i++) {
-    auto simBoundingBoxMsg = simMsg.boundingBoxesArray._buffer[i];
-    vrxperience_msgs::msg::MovableTargetBoundingBox rosBoundingBoxMsg;
-
-    rosBoundingBoxMsg.header.stamp.sec = static_cast<int>(simMsg.timeOfUpdate);
-    rosBoundingBoxMsg.header.stamp.nanosec =
-      (static_cast<int>(simMsg.timeOfUpdate * 1e9)) % (static_cast<int>(1e9));
-
-    switch (simBoundingBoxMsg.referenceFrame) {
-      case WORLD_FRAME:
-        rosBoundingBoxMsg.header.frame_id = world_frame;
-        break;
-      case VEHICLE_FRAME:
-        rosBoundingBoxMsg.header.frame_id = vehicle_frame;
-        break;
-      case SENSOR_FRAME:
-        rosBoundingBoxMsg.header.frame_id = sensor_frame;
-        break;
-    }
-
-    rosBoundingBoxMsg.id = simBoundingBoxMsg.id;
-
-    rosBoundingBoxMsg.rear_bottom_right.x = simBoundingBoxMsg.rearBottomRightX;
-    rosBoundingBoxMsg.rear_bottom_right.y = simBoundingBoxMsg.rearBottomRightY;
-    rosBoundingBoxMsg.rear_bottom_right.z = simBoundingBoxMsg.rearBottomRightZ;
-
-    rosBoundingBoxMsg.rear_top_right.x = simBoundingBoxMsg.rearTopRightX;
-    rosBoundingBoxMsg.rear_top_right.y = simBoundingBoxMsg.rearTopRightY;
-    rosBoundingBoxMsg.rear_top_right.z = simBoundingBoxMsg.rearTopRightZ;
-
-    rosBoundingBoxMsg.rear_bottom_left.x = simBoundingBoxMsg.rearbottomLeftX;
-    rosBoundingBoxMsg.rear_bottom_left.y = simBoundingBoxMsg.rearbottomLeftY;
-    rosBoundingBoxMsg.rear_bottom_left.z = simBoundingBoxMsg.rearbottomLeftZ;
-
-    rosBoundingBoxMsg.rear_top_left.x = simBoundingBoxMsg.rearTopLeftX;
-    rosBoundingBoxMsg.rear_top_left.y = simBoundingBoxMsg.rearTopLeftY;
-    rosBoundingBoxMsg.rear_top_left.z = simBoundingBoxMsg.rearTopLeftZ;
-
-    rosBoundingBoxMsg.front_bottom_right.x = simBoundingBoxMsg.frontBottomRightX;
-    rosBoundingBoxMsg.front_bottom_right.y = simBoundingBoxMsg.frontBottomRightY;
-    rosBoundingBoxMsg.front_bottom_right.z = simBoundingBoxMsg.frontBottomRightZ;
-
-    rosBoundingBoxMsg.front_top_right.x = simBoundingBoxMsg.frontTopRightX;
-    rosBoundingBoxMsg.front_top_right.y = simBoundingBoxMsg.frontTopRightY;
-    rosBoundingBoxMsg.front_top_right.z = simBoundingBoxMsg.frontTopRightZ;
-
-    rosBoundingBoxMsg.front_bottom_left.x = simBoundingBoxMsg.frontbottomLeftX;
-    rosBoundingBoxMsg.front_bottom_left.y = simBoundingBoxMsg.frontbottomLeftY;
-    rosBoundingBoxMsg.front_bottom_left.z = simBoundingBoxMsg.frontbottomLeftZ;
-
-    rosBoundingBoxMsg.front_top_left.x = simBoundingBoxMsg.frontTopLeftX;
-    rosBoundingBoxMsg.front_top_left.y = simBoundingBoxMsg.frontTopLeftY;
-    rosBoundingBoxMsg.front_top_left.z = simBoundingBoxMsg.frontTopLeftZ;
-
-    rosMsg.bounding_boxes.push_back(rosBoundingBoxMsg);
+class MovableTargetsBoundingBoxesReceiver
+  : public SimDataReceiver<IndyDS_SensorMovableTargetsBoundingBoxes,
+    vrxperience_msgs::msg::MovableTargetsBoundingBoxes>
+{
+public:
+  explicit MovableTargetsBoundingBoxesReceiver(const rclcpp::NodeOptions & options)
+  : SimDataReceiver(
+      "recv_movable_targets_bounding_boxes",
+      options,
+      IndyDS_SensorMovableTargetsBoundingBoxes_desc,
+      std::bind(&MovableTargetsBoundingBoxesReceiver::convert, this, _1, _2)
+  )
+  {
+    world_frame_ = declare_parameter("world_frame", "world");
+    vehicle_frame_ = declare_parameter("vehicle_frame", "base_link");
+    sensor_frame_ = declare_parameter("sensor_frame", "");
   }
-}
 
-int main(int argc, char * argv[])
-{
-  rclcpp::init(argc, argv);
-  MovableTargetsBoundingBoxesReceiver receiver("recv_movable_targets_bounding_boxes",
-    IndyDS_SensorMovableTargetsBoundingBoxes_desc,
-    &convert);
+  void convert(
+    IndyDS_SensorMovableTargetsBoundingBoxes IN simMsg,
+    vrxperience_msgs::msg::MovableTargetsBoundingBoxes OUT rosMsg)
+  {
+    rosMsg.header.stamp.sec = static_cast<int>(simMsg.timeOfUpdate);
+    rosMsg.header.stamp.nanosec =
+      (static_cast<int>(simMsg.timeOfUpdate * 1e9)) % (static_cast<int>(1e9));
+    rosMsg.header.frame_id = sensor_frame_;
 
-  world_frame = receiver.declare_parameter("world_frame", "world");
-  vehicle_frame = receiver.declare_parameter("vehicle_frame", "base_link");
-  sensor_frame = receiver.declare_parameter("sensor_frame", "");
-  receiver.run();
-}
+    rosMsg.global_id = simMsg.globalId;
+    rosMsg.ego_vehicle_id = simMsg.vhlId;
+
+    for (uint32_t i = 0; i < simMsg.boundingBoxesArray._length; i++) {
+      auto simBoundingBoxMsg = simMsg.boundingBoxesArray._buffer[i];
+      vrxperience_msgs::msg::MovableTargetBoundingBox rosBoundingBoxMsg;
+
+      rosBoundingBoxMsg.header.stamp.sec = static_cast<int>(simMsg.timeOfUpdate);
+      rosBoundingBoxMsg.header.stamp.nanosec =
+        (static_cast<int>(simMsg.timeOfUpdate * 1e9)) % (static_cast<int>(1e9));
+
+      switch (simBoundingBoxMsg.referenceFrame) {
+        case WORLD_FRAME:
+          rosBoundingBoxMsg.header.frame_id = world_frame_;
+          break;
+        case VEHICLE_FRAME:
+          rosBoundingBoxMsg.header.frame_id = vehicle_frame_;
+          break;
+        case SENSOR_FRAME:
+          rosBoundingBoxMsg.header.frame_id = sensor_frame_;
+          break;
+      }
+
+      rosBoundingBoxMsg.id = simBoundingBoxMsg.id;
+
+      rosBoundingBoxMsg.rear_bottom_right.x = simBoundingBoxMsg.rearBottomRightX;
+      rosBoundingBoxMsg.rear_bottom_right.y = simBoundingBoxMsg.rearBottomRightY;
+      rosBoundingBoxMsg.rear_bottom_right.z = simBoundingBoxMsg.rearBottomRightZ;
+
+      rosBoundingBoxMsg.rear_top_right.x = simBoundingBoxMsg.rearTopRightX;
+      rosBoundingBoxMsg.rear_top_right.y = simBoundingBoxMsg.rearTopRightY;
+      rosBoundingBoxMsg.rear_top_right.z = simBoundingBoxMsg.rearTopRightZ;
+
+      rosBoundingBoxMsg.rear_bottom_left.x = simBoundingBoxMsg.rearbottomLeftX;
+      rosBoundingBoxMsg.rear_bottom_left.y = simBoundingBoxMsg.rearbottomLeftY;
+      rosBoundingBoxMsg.rear_bottom_left.z = simBoundingBoxMsg.rearbottomLeftZ;
+
+      rosBoundingBoxMsg.rear_top_left.x = simBoundingBoxMsg.rearTopLeftX;
+      rosBoundingBoxMsg.rear_top_left.y = simBoundingBoxMsg.rearTopLeftY;
+      rosBoundingBoxMsg.rear_top_left.z = simBoundingBoxMsg.rearTopLeftZ;
+
+      rosBoundingBoxMsg.front_bottom_right.x = simBoundingBoxMsg.frontBottomRightX;
+      rosBoundingBoxMsg.front_bottom_right.y = simBoundingBoxMsg.frontBottomRightY;
+      rosBoundingBoxMsg.front_bottom_right.z = simBoundingBoxMsg.frontBottomRightZ;
+
+      rosBoundingBoxMsg.front_top_right.x = simBoundingBoxMsg.frontTopRightX;
+      rosBoundingBoxMsg.front_top_right.y = simBoundingBoxMsg.frontTopRightY;
+      rosBoundingBoxMsg.front_top_right.z = simBoundingBoxMsg.frontTopRightZ;
+
+      rosBoundingBoxMsg.front_bottom_left.x = simBoundingBoxMsg.frontbottomLeftX;
+      rosBoundingBoxMsg.front_bottom_left.y = simBoundingBoxMsg.frontbottomLeftY;
+      rosBoundingBoxMsg.front_bottom_left.z = simBoundingBoxMsg.frontbottomLeftZ;
+
+      rosBoundingBoxMsg.front_top_left.x = simBoundingBoxMsg.frontTopLeftX;
+      rosBoundingBoxMsg.front_top_left.y = simBoundingBoxMsg.frontTopLeftY;
+      rosBoundingBoxMsg.front_top_left.z = simBoundingBoxMsg.frontTopLeftZ;
+
+      rosMsg.bounding_boxes.push_back(rosBoundingBoxMsg);
+    }
+  }
+
+private:
+  std::string world_frame_;
+  std::string vehicle_frame_;
+  std::string sensor_frame_;
+};  // class MovableTargetsBoundingBoxesReceiver
+
+}  // namespace vrxperience_bridge
+
+#include <rclcpp_components/register_node_macro.hpp>  // NOLINT
+RCLCPP_COMPONENTS_REGISTER_NODE(vrxperience_bridge::MovableTargetsBoundingBoxesReceiver)

--- a/vrxperience_bridge/src/recv_movable_targets_bounding_boxes.cpp
+++ b/vrxperience_bridge/src/recv_movable_targets_bounding_boxes.cpp
@@ -40,8 +40,8 @@ public:
   }
 
   void convert(
-    IndyDS_SensorMovableTargetsBoundingBoxes IN simMsg,
-    vrxperience_msgs::msg::MovableTargetsBoundingBoxes OUT rosMsg)
+    const IndyDS_SensorMovableTargetsBoundingBoxes & simMsg,
+    vrxperience_msgs::msg::MovableTargetsBoundingBoxes & rosMsg)
   {
     rosMsg.header.stamp.sec = static_cast<int>(simMsg.timeOfUpdate);
     rosMsg.header.stamp.nanosec =

--- a/vrxperience_bridge/src/recv_road_lines_polynoms.cpp
+++ b/vrxperience_bridge/src/recv_road_lines_polynoms.cpp
@@ -18,67 +18,76 @@
 #include "vrxperience_msgs/msg/road_lines_polynoms.hpp"
 #include "IndyDS_RoadLinesPolynoms.h"
 
-using vrxperience_bridge::SimDataReceiver;
-typedef SimDataReceiver<IndyDS_RoadLinesPolynoms,
-    vrxperience_msgs::msg::RoadLinesPolynoms> RoadLinesPolynomsReceiver;
-
-const int WORLD_FRAME = 0;
-const int VEHICLE_FRAME = 1;
-const int SENSOR_FRAME = 2;
-
-std::string world_frame;  // NOLINT
-std::string vehicle_frame;  // NOLINT
-std::string sensor_frame;  // NOLINT
-
-void convert(
-  IndyDS_RoadLinesPolynoms IN simMsg,
-  vrxperience_msgs::msg::RoadLinesPolynoms OUT rosMsg)
+namespace vrxperience_bridge
 {
-  rosMsg.header.stamp.sec = static_cast<int>(simMsg.timeOfUpdate);
-  rosMsg.header.stamp.nanosec =
-    (static_cast<int>(simMsg.timeOfUpdate * 1e9)) % (static_cast<int>(1e9));
 
-  switch (simMsg.referenceFrame) {
-    case WORLD_FRAME:
-      rosMsg.header.frame_id = world_frame;
-      break;
-    case VEHICLE_FRAME:
-      rosMsg.header.frame_id = vehicle_frame;
-      break;
-    case SENSOR_FRAME:
-      rosMsg.header.frame_id = sensor_frame;
-      break;
+class RoadLinesPolynomsReceiver
+  : public SimDataReceiver<IndyDS_RoadLinesPolynoms,
+    vrxperience_msgs::msg::RoadLinesPolynoms>
+{
+public:
+  explicit RoadLinesPolynomsReceiver(const rclcpp::NodeOptions & options)
+  : SimDataReceiver(
+      "recv_road_lines_polynoms",
+      options,
+      IndyDS_RoadLinesPolynoms_desc,
+      std::bind(&RoadLinesPolynomsReceiver::convert, this, _1, _2)
+  )
+  {
+    world_frame_ = declare_parameter("world_frame", "world");
+    vehicle_frame_ = declare_parameter("vehicle_frame", "base_link");
+    sensor_frame_ = declare_parameter("sensor_frame", "");
   }
 
-  rosMsg.global_id = simMsg.globalId;
-  rosMsg.ego_vehicle_id = simMsg.egoVhlId;
-  rosMsg.is_noisy = simMsg.isNoisy;
+  void convert(
+    IndyDS_RoadLinesPolynoms IN simMsg,
+    vrxperience_msgs::msg::RoadLinesPolynoms OUT rosMsg)
+  {
+    rosMsg.header.stamp.sec = static_cast<int>(simMsg.timeOfUpdate);
+    rosMsg.header.stamp.nanosec =
+      (static_cast<int>(simMsg.timeOfUpdate * 1e9)) % (static_cast<int>(1e9));
 
-  for (uint32_t i = 0; i < simMsg.roadLinesPolynomsArray._length; i++) {
-    auto simPolynomMsg = simMsg.roadLinesPolynomsArray._buffer[i];
-    vrxperience_msgs::msg::RoadLinePolynom rosPolynomMsg;
+    switch (simMsg.referenceFrame) {
+      case WORLD_FRAME:
+        rosMsg.header.frame_id = world_frame_;
+        break;
+      case VEHICLE_FRAME:
+        rosMsg.header.frame_id = vehicle_frame_;
+        break;
+      case SENSOR_FRAME:
+        rosMsg.header.frame_id = sensor_frame_;
+        break;
+    }
 
-    rosPolynomMsg.line_id = simPolynomMsg.lineId;
+    rosMsg.global_id = simMsg.globalId;
+    rosMsg.ego_vehicle_id = simMsg.egoVhlId;
+    rosMsg.is_noisy = simMsg.isNoisy;
 
-    rosPolynomMsg.c0 = simPolynomMsg.c0;
-    rosPolynomMsg.c1 = simPolynomMsg.c1;
-    rosPolynomMsg.c2 = simPolynomMsg.c2;
-    rosPolynomMsg.c3 = simPolynomMsg.c3;
+    for (uint32_t i = 0; i < simMsg.roadLinesPolynomsArray._length; i++) {
+      auto simPolynomMsg = simMsg.roadLinesPolynomsArray._buffer[i];
+      vrxperience_msgs::msg::RoadLinePolynom rosPolynomMsg;
 
-    rosPolynomMsg.curvature_radius = simPolynomMsg.curvatureRadius;
-    rosPolynomMsg.estimated_curvature_radius = simPolynomMsg.estimatedCurvatureRadius;
+      rosPolynomMsg.line_id = simPolynomMsg.lineId;
 
-    rosMsg.polynoms.push_back(rosPolynomMsg);
+      rosPolynomMsg.c0 = simPolynomMsg.c0;
+      rosPolynomMsg.c1 = simPolynomMsg.c1;
+      rosPolynomMsg.c2 = simPolynomMsg.c2;
+      rosPolynomMsg.c3 = simPolynomMsg.c3;
+
+      rosPolynomMsg.curvature_radius = simPolynomMsg.curvatureRadius;
+      rosPolynomMsg.estimated_curvature_radius = simPolynomMsg.estimatedCurvatureRadius;
+
+      rosMsg.polynoms.push_back(rosPolynomMsg);
+    }
   }
-}
 
-int main(int argc, char * argv[])
-{
-  rclcpp::init(argc, argv);
-  RoadLinesPolynomsReceiver receiver("recv_road_lines_polynoms", IndyDS_RoadLinesPolynoms_desc,
-    &convert);
-  world_frame = receiver.declare_parameter("world_frame", "world");
-  vehicle_frame = receiver.declare_parameter("vehicle_frame", "base_link");
-  sensor_frame = receiver.declare_parameter("sensor_frame", "");
-  receiver.run();
-}
+private:
+  std::string world_frame_;
+  std::string vehicle_frame_;
+  std::string sensor_frame_;
+};  // class RoadLinesPolynomsReceiver
+
+}  // namespace vrxperience_bridge
+
+#include <rclcpp_components/register_node_macro.hpp>  // NOLINT
+RCLCPP_COMPONENTS_REGISTER_NODE(vrxperience_bridge::RoadLinesPolynomsReceiver)

--- a/vrxperience_bridge/src/recv_road_lines_polynoms.cpp
+++ b/vrxperience_bridge/src/recv_road_lines_polynoms.cpp
@@ -40,8 +40,8 @@ public:
   }
 
   void convert(
-    IndyDS_RoadLinesPolynoms IN simMsg,
-    vrxperience_msgs::msg::RoadLinesPolynoms OUT rosMsg)
+    const IndyDS_RoadLinesPolynoms & simMsg,
+    vrxperience_msgs::msg::RoadLinesPolynoms & rosMsg)
   {
     rosMsg.header.stamp.sec = static_cast<int>(simMsg.timeOfUpdate);
     rosMsg.header.stamp.nanosec =

--- a/vrxperience_bridge/src/recv_vehicle_output.cpp
+++ b/vrxperience_bridge/src/recv_vehicle_output.cpp
@@ -36,7 +36,7 @@ public:
   {
   }
 
-  void convert(IndyDS_VehicleOutput IN simMsg, vrxperience_msgs::msg::VehicleOutput OUT rosMsg)
+  void convert(const IndyDS_VehicleOutput & simMsg, vrxperience_msgs::msg::VehicleOutput & rosMsg)
   {
     rosMsg.header.stamp.sec = static_cast<int>(simMsg.TimeOfUpdate);
     rosMsg.header.stamp.nanosec =

--- a/vrxperience_bridge/src/recv_vehicle_output.cpp
+++ b/vrxperience_bridge/src/recv_vehicle_output.cpp
@@ -18,113 +18,126 @@
 #include "vrxperience_msgs/msg/vehicle_output.hpp"
 #include "IndyDS_VehicleOutput.h"
 
-using vrxperience_bridge::SimDataReceiver;
-typedef SimDataReceiver<IndyDS_VehicleOutput,
-    vrxperience_msgs::msg::VehicleOutput> VehicleOutputReceiver;
-
-void convert(IndyDS_VehicleOutput IN simMsg, vrxperience_msgs::msg::VehicleOutput OUT rosMsg)
+namespace vrxperience_bridge
 {
-  rosMsg.header.stamp.sec = static_cast<int>(simMsg.TimeOfUpdate);
-  rosMsg.header.stamp.nanosec =
-    (static_cast<int>(simMsg.TimeOfUpdate * 1e9)) % (static_cast<int>(1e9));
 
-  rosMsg.cdg_speed.x = simMsg.cdgSpeed_x;
-  rosMsg.cdg_speed.y = simMsg.cdgSpeed_y;
-  rosMsg.cdg_speed.z = simMsg.cdgSpeed_z;
-
-  rosMsg.cdg_angular_speed.x = simMsg.cdgSpeed_roll;
-  rosMsg.cdg_angular_speed.y = simMsg.cdgSpeed_pitch;
-  rosMsg.cdg_angular_speed.z = simMsg.cdgSpeed_heading;
-
-  rosMsg.cdg_accel.x = simMsg.cdgAccel_x;
-  rosMsg.cdg_accel.y = simMsg.cdgAccel_y;
-  rosMsg.cdg_accel.z = simMsg.cdgAccel_z;
-
-  rosMsg.cdg_angular_accel.x = simMsg.cdgAccel_roll;
-  rosMsg.cdg_angular_accel.y = simMsg.cdgAccel_pitch;
-  rosMsg.cdg_angular_accel.z = simMsg.cdgAccel_heading;
-
-  rosMsg.cdg_position.x = simMsg.cdgPos_x;
-  rosMsg.cdg_position.y = simMsg.cdgPos_y;
-  rosMsg.cdg_position.z = simMsg.cdgPos_z;
-
-  rosMsg.cdg_orientation.x = simMsg.cdgPos_roll;
-  rosMsg.cdg_orientation.y = simMsg.cdgPos_pitch;
-  rosMsg.cdg_orientation.z = simMsg.cdgPos_heading;
-
-  rosMsg.lights = simMsg.lights;
-  rosMsg.sirens = simMsg.sirens;
-  rosMsg.auxilary_lights = simMsg.auxiliaryLights;
-  rosMsg.engine_state = simMsg.EngineState;
-  rosMsg.consumption = simMsg.consumption;
-  rosMsg.pollution = simMsg.pollution;
-  rosMsg.engine_speed = simMsg.EngineSpeed;
-  rosMsg.gear_engaged = simMsg.GearEngaged;
-  rosMsg.gas_pedal = simMsg.gasPedal;
-  rosMsg.brake_pedal = simMsg.brakePedal;
-  rosMsg.hand_brake = simMsg.handBrake;
-  rosMsg.clutch_pedal = simMsg.clutchPedal;
-  rosMsg.gear_box_mode = simMsg.GearBoxMode;
-  rosMsg.effective_ignition_key_position = simMsg.effectiveIgnitionKeyPosition;
-  rosMsg.is_engine_retarder = simMsg.isEngineRetarder;
-  rosMsg.brake_retarder_notch = simMsg.brakeRetarderNotch;
-  rosMsg.transfer_choice = simMsg.transferChoice;
-  rosMsg.lock_diff_mode = simMsg.lockDiffMode;
-  rosMsg.force_lockup = simMsg.forceLockup;
-  rosMsg.steering_wheel_angle = simMsg.SteeringWheelAngle;
-  rosMsg.steering_wheel_speed = simMsg.SteeringWheelSpeed;
-  rosMsg.steering_wheel_accel = simMsg.SteeringWheelAccel;
-  rosMsg.steering_wheel_torque = simMsg.SteeringWheelTorque;
-
-  for (int i = 0; i < 4; i++) {
-    rosMsg.hub_position[i].x = simMsg.hubPosition_x[i];
-    rosMsg.hub_position[i].y = simMsg.hubPosition_y[i];
-    rosMsg.hub_position[i].z = simMsg.hubPosition_z[i];
-
-    rosMsg.hub_orientation[i].x = simMsg.hubPosition_roll[i];
-    rosMsg.hub_orientation[i].y = simMsg.hubPosition_pitch[i];
-    rosMsg.hub_orientation[i].z = simMsg.hubPosition_heading[i];
-
-    rosMsg.wheel_rotation[i] = simMsg.wheelRotation[i];
-    rosMsg.wheel_rotation_speed[i] = simMsg.wheelRotationSpeed[i];
-    rosMsg.brake_temperature[i] = simMsg.brakeTemperature[i];
-    rosMsg.abs_is_active[i] = simMsg.absIsActive[i];
-    rosMsg.is_in_contact[i] = simMsg.isInContact[i];
-
-    rosMsg.contact_points[i].x = simMsg.contactPoint_x[i];
-    rosMsg.contact_points[i].y = simMsg.contactPoint_y[i];
-    rosMsg.contact_points[i].z = simMsg.contactPoint_z[i];
-
-    rosMsg.ground_normals[i].x = simMsg.groundNormal_x[i];
-    rosMsg.ground_normals[i].y = simMsg.groundNormal_y[i];
-    rosMsg.ground_normals[i].z = simMsg.groundNormal_z[i];
-
-    rosMsg.grip[i] = simMsg.grip[i];
-    rosMsg.ground_index[i] = simMsg.GroundIndex[i];
-    rosMsg.lsr[i] = simMsg.LSR[i];
-    rosMsg.slip_angle[i] = simMsg.slipAngle[i];
-
-    rosMsg.tire_force[i].x = simMsg.tireForce_x[i];
-    rosMsg.tire_force[i].y = simMsg.tireForce_y[i];
-    rosMsg.tire_force[i].z = simMsg.tireForce_z[i];
-
-    rosMsg.lane_type[i] = simMsg.laneType[i];
-    rosMsg.roughness_height[i] = simMsg.roughnessHeight[i];
-    rosMsg.roughness_length[i] = simMsg.roughnessLength[i];
-    rosMsg.roughness_height_stddev[i] = simMsg.roughnessHeightStdDeviation[i];
-    rosMsg.roughness_length_stddev[i] = simMsg.roughnessLengthStdDeviation[i];
-    rosMsg.ground_type[i] = simMsg.groundType[i];
-    rosMsg.water_height[i] = simMsg.waterHeight[i];
+class VehicleOutputReceiver
+  : public SimDataReceiver<IndyDS_VehicleOutput,
+    vrxperience_msgs::msg::VehicleOutput>
+{
+public:
+  explicit VehicleOutputReceiver(const rclcpp::NodeOptions & options)
+  : SimDataReceiver(
+      "recv_vehicle_output",
+      options,
+      IndyDS_VehicleOutput_desc,
+      std::bind(&VehicleOutputReceiver::convert, this, _1, _2)
+  )
+  {
   }
 
-  for (int i = 0; i < 512; i++) {
-    rosMsg.custom_output[i] = simMsg.CustomOutput[i];
-  }
-}
+  void convert(IndyDS_VehicleOutput IN simMsg, vrxperience_msgs::msg::VehicleOutput OUT rosMsg)
+  {
+    rosMsg.header.stamp.sec = static_cast<int>(simMsg.TimeOfUpdate);
+    rosMsg.header.stamp.nanosec =
+      (static_cast<int>(simMsg.TimeOfUpdate * 1e9)) % (static_cast<int>(1e9));
 
-int main(int argc, char * argv[])
-{
-  rclcpp::init(argc, argv);
-  VehicleOutputReceiver receiver("recv_vehicle_output", IndyDS_VehicleOutput_desc, &convert);
-  receiver.run();
-}
+    rosMsg.cdg_speed.x = simMsg.cdgSpeed_x;
+    rosMsg.cdg_speed.y = simMsg.cdgSpeed_y;
+    rosMsg.cdg_speed.z = simMsg.cdgSpeed_z;
+
+    rosMsg.cdg_angular_speed.x = simMsg.cdgSpeed_roll;
+    rosMsg.cdg_angular_speed.y = simMsg.cdgSpeed_pitch;
+    rosMsg.cdg_angular_speed.z = simMsg.cdgSpeed_heading;
+
+    rosMsg.cdg_accel.x = simMsg.cdgAccel_x;
+    rosMsg.cdg_accel.y = simMsg.cdgAccel_y;
+    rosMsg.cdg_accel.z = simMsg.cdgAccel_z;
+
+    rosMsg.cdg_angular_accel.x = simMsg.cdgAccel_roll;
+    rosMsg.cdg_angular_accel.y = simMsg.cdgAccel_pitch;
+    rosMsg.cdg_angular_accel.z = simMsg.cdgAccel_heading;
+
+    rosMsg.cdg_position.x = simMsg.cdgPos_x;
+    rosMsg.cdg_position.y = simMsg.cdgPos_y;
+    rosMsg.cdg_position.z = simMsg.cdgPos_z;
+
+    rosMsg.cdg_orientation.x = simMsg.cdgPos_roll;
+    rosMsg.cdg_orientation.y = simMsg.cdgPos_pitch;
+    rosMsg.cdg_orientation.z = simMsg.cdgPos_heading;
+
+    rosMsg.lights = simMsg.lights;
+    rosMsg.sirens = simMsg.sirens;
+    rosMsg.auxilary_lights = simMsg.auxiliaryLights;
+    rosMsg.engine_state = simMsg.EngineState;
+    rosMsg.consumption = simMsg.consumption;
+    rosMsg.pollution = simMsg.pollution;
+    rosMsg.engine_speed = simMsg.EngineSpeed;
+    rosMsg.gear_engaged = simMsg.GearEngaged;
+    rosMsg.gas_pedal = simMsg.gasPedal;
+    rosMsg.brake_pedal = simMsg.brakePedal;
+    rosMsg.hand_brake = simMsg.handBrake;
+    rosMsg.clutch_pedal = simMsg.clutchPedal;
+    rosMsg.gear_box_mode = simMsg.GearBoxMode;
+    rosMsg.effective_ignition_key_position = simMsg.effectiveIgnitionKeyPosition;
+    rosMsg.is_engine_retarder = simMsg.isEngineRetarder;
+    rosMsg.brake_retarder_notch = simMsg.brakeRetarderNotch;
+    rosMsg.transfer_choice = simMsg.transferChoice;
+    rosMsg.lock_diff_mode = simMsg.lockDiffMode;
+    rosMsg.force_lockup = simMsg.forceLockup;
+    rosMsg.steering_wheel_angle = simMsg.SteeringWheelAngle;
+    rosMsg.steering_wheel_speed = simMsg.SteeringWheelSpeed;
+    rosMsg.steering_wheel_accel = simMsg.SteeringWheelAccel;
+    rosMsg.steering_wheel_torque = simMsg.SteeringWheelTorque;
+
+    for (int i = 0; i < 4; i++) {
+      rosMsg.hub_position[i].x = simMsg.hubPosition_x[i];
+      rosMsg.hub_position[i].y = simMsg.hubPosition_y[i];
+      rosMsg.hub_position[i].z = simMsg.hubPosition_z[i];
+
+      rosMsg.hub_orientation[i].x = simMsg.hubPosition_roll[i];
+      rosMsg.hub_orientation[i].y = simMsg.hubPosition_pitch[i];
+      rosMsg.hub_orientation[i].z = simMsg.hubPosition_heading[i];
+
+      rosMsg.wheel_rotation[i] = simMsg.wheelRotation[i];
+      rosMsg.wheel_rotation_speed[i] = simMsg.wheelRotationSpeed[i];
+      rosMsg.brake_temperature[i] = simMsg.brakeTemperature[i];
+      rosMsg.abs_is_active[i] = simMsg.absIsActive[i];
+      rosMsg.is_in_contact[i] = simMsg.isInContact[i];
+
+      rosMsg.contact_points[i].x = simMsg.contactPoint_x[i];
+      rosMsg.contact_points[i].y = simMsg.contactPoint_y[i];
+      rosMsg.contact_points[i].z = simMsg.contactPoint_z[i];
+
+      rosMsg.ground_normals[i].x = simMsg.groundNormal_x[i];
+      rosMsg.ground_normals[i].y = simMsg.groundNormal_y[i];
+      rosMsg.ground_normals[i].z = simMsg.groundNormal_z[i];
+
+      rosMsg.grip[i] = simMsg.grip[i];
+      rosMsg.ground_index[i] = simMsg.GroundIndex[i];
+      rosMsg.lsr[i] = simMsg.LSR[i];
+      rosMsg.slip_angle[i] = simMsg.slipAngle[i];
+
+      rosMsg.tire_force[i].x = simMsg.tireForce_x[i];
+      rosMsg.tire_force[i].y = simMsg.tireForce_y[i];
+      rosMsg.tire_force[i].z = simMsg.tireForce_z[i];
+
+      rosMsg.lane_type[i] = simMsg.laneType[i];
+      rosMsg.roughness_height[i] = simMsg.roughnessHeight[i];
+      rosMsg.roughness_length[i] = simMsg.roughnessLength[i];
+      rosMsg.roughness_height_stddev[i] = simMsg.roughnessHeightStdDeviation[i];
+      rosMsg.roughness_length_stddev[i] = simMsg.roughnessLengthStdDeviation[i];
+      rosMsg.ground_type[i] = simMsg.groundType[i];
+      rosMsg.water_height[i] = simMsg.waterHeight[i];
+    }
+
+    for (int i = 0; i < 512; i++) {
+      rosMsg.custom_output[i] = simMsg.CustomOutput[i];
+    }
+  }
+};  // class VehicleOutputReceiver
+
+}  // namespace vrxperience_bridge
+
+#include <rclcpp_components/register_node_macro.hpp>  // NOLINT
+RCLCPP_COMPONENTS_REGISTER_NODE(vrxperience_bridge::VehicleOutputReceiver)

--- a/vrxperience_bridge/src/send_cab_to_model_corrective.cpp
+++ b/vrxperience_bridge/src/send_cab_to_model_corrective.cpp
@@ -12,46 +12,53 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <memory>
-
 #include "vrxperience_bridge/sim_data_sender.hpp"
 #include "vrxperience_msgs/msg/cab_to_model_corrective.hpp"
 #include "IndyDS_CabToModelCorrective.h"
 
-using vrxperience_bridge::SimDataSender;
-typedef SimDataSender<vrxperience_msgs::msg::CabToModelCorrective,
-    IndyDS_CabToModelCorrective> CabToModelCorrectiveSender;
-
-void convert(
-  vrxperience_msgs::msg::CabToModelCorrective IN rosMsg,
-  IndyDS_CabToModelCorrective OUT simMsg)
+namespace vrxperience_bridge
 {
-  simMsg.TimeOfUpdate = rosMsg.header.stamp.sec + rosMsg.header.stamp.nanosec * 1e-9;
-  simMsg.AcceleratorAdditive = rosMsg.accelerator_additive;
-  simMsg.AcceleratorMultiplicative = rosMsg.accelerator_multiplicative;
-  simMsg.BrakeAdditive = rosMsg.brake_additive;
-  simMsg.BrakeMultiplicative = rosMsg.brake_multiplicative;
-  simMsg.ClutchAdditive = rosMsg.clutch_additive;
-  simMsg.ClutchMultiplicative = rosMsg.clutch_multiplicative;
-  simMsg.ParkingBrakeAdditive = rosMsg.parking_brake_additive;
-  simMsg.ParkingBrakeMultiplicative = rosMsg.parking_brake_multiplicative;
-  simMsg.GearboxTakeOver = rosMsg.gear_box_take_over;
-  simMsg.GearboxAutoMode = rosMsg.gear_box_auto_mode;
-  simMsg.WantedGear = rosMsg.wanted_gear;
-  simMsg.ShiftUp = rosMsg.shift_up;
-  simMsg.ShiftDown = rosMsg.shift_down;
-  simMsg.IsRatioLimit = rosMsg.is_ratio_limit;
-  simMsg.MinRatio = rosMsg.min_ratio;
-  simMsg.MaxRatio = rosMsg.max_ratio;
-}
 
-int main(int argc, char * argv[])
+class CabToModelCorrectiveSender
+  : public SimDataSender<vrxperience_msgs::msg::CabToModelCorrective,
+    IndyDS_CabToModelCorrective>
 {
-  rclcpp::init(argc, argv);
-  auto sender = std::make_shared<CabToModelCorrectiveSender>(
-    "send_cab_to_model_corrective",
-    IndyDS_CabToModelCorrective_desc,
-    &convert);
+public:
+  explicit CabToModelCorrectiveSender(const rclcpp::NodeOptions & options)
+  : SimDataSender(
+      "send_cab_to_model_corrective",
+      options,
+      IndyDS_CabToModelCorrective_desc,
+      std::bind(&CabToModelCorrectiveSender::convert, this, _1, _2)
+  )
+  {
+  }
 
-  rclcpp::spin(sender);
-}
+  void convert(
+    vrxperience_msgs::msg::CabToModelCorrective IN rosMsg,
+    IndyDS_CabToModelCorrective OUT simMsg)
+  {
+    simMsg.TimeOfUpdate = rosMsg.header.stamp.sec + rosMsg.header.stamp.nanosec * 1e-9;
+    simMsg.AcceleratorAdditive = rosMsg.accelerator_additive;
+    simMsg.AcceleratorMultiplicative = rosMsg.accelerator_multiplicative;
+    simMsg.BrakeAdditive = rosMsg.brake_additive;
+    simMsg.BrakeMultiplicative = rosMsg.brake_multiplicative;
+    simMsg.ClutchAdditive = rosMsg.clutch_additive;
+    simMsg.ClutchMultiplicative = rosMsg.clutch_multiplicative;
+    simMsg.ParkingBrakeAdditive = rosMsg.parking_brake_additive;
+    simMsg.ParkingBrakeMultiplicative = rosMsg.parking_brake_multiplicative;
+    simMsg.GearboxTakeOver = rosMsg.gear_box_take_over;
+    simMsg.GearboxAutoMode = rosMsg.gear_box_auto_mode;
+    simMsg.WantedGear = rosMsg.wanted_gear;
+    simMsg.ShiftUp = rosMsg.shift_up;
+    simMsg.ShiftDown = rosMsg.shift_down;
+    simMsg.IsRatioLimit = rosMsg.is_ratio_limit;
+    simMsg.MinRatio = rosMsg.min_ratio;
+    simMsg.MaxRatio = rosMsg.max_ratio;
+  }
+};  // class CabToModelCorrectiveSender
+
+}  // namespace vrxperience_bridge
+
+#include <rclcpp_components/register_node_macro.hpp>  // NOLINT
+RCLCPP_COMPONENTS_REGISTER_NODE(vrxperience_bridge::CabToModelCorrectiveSender)

--- a/vrxperience_bridge/src/send_cab_to_model_corrective.cpp
+++ b/vrxperience_bridge/src/send_cab_to_model_corrective.cpp
@@ -35,8 +35,8 @@ public:
   }
 
   void convert(
-    vrxperience_msgs::msg::CabToModelCorrective IN rosMsg,
-    IndyDS_CabToModelCorrective OUT simMsg)
+    const vrxperience_msgs::msg::CabToModelCorrective & rosMsg,
+    IndyDS_CabToModelCorrective & simMsg)
   {
     simMsg.TimeOfUpdate = rosMsg.header.stamp.sec + rosMsg.header.stamp.nanosec * 1e-9;
     simMsg.AcceleratorAdditive = rosMsg.accelerator_additive;

--- a/vrxperience_bridge/src/send_cab_to_steering_corrective.cpp
+++ b/vrxperience_bridge/src/send_cab_to_steering_corrective.cpp
@@ -35,8 +35,8 @@ public:
   }
 
   void convert(
-    vrxperience_msgs::msg::CabToSteeringCorrective IN rosMsg,
-    IndyDS_CabToSteeringCorrective OUT simMsg)
+    const vrxperience_msgs::msg::CabToSteeringCorrective & rosMsg,
+    IndyDS_CabToSteeringCorrective & simMsg)
   {
     simMsg.TimeOfUpdate = rosMsg.header.stamp.sec + rosMsg.header.stamp.nanosec * 1e-9;
     simMsg.AdditiveSteeringWheelAngle = rosMsg.additive_steering_wheel_angle;

--- a/vrxperience_bridge/src/send_cab_to_steering_corrective.cpp
+++ b/vrxperience_bridge/src/send_cab_to_steering_corrective.cpp
@@ -12,38 +12,45 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <memory>
-
 #include "vrxperience_bridge/sim_data_sender.hpp"
 #include "vrxperience_msgs/msg/cab_to_steering_corrective.hpp"
 #include "IndyDS_CabToSteeringCorrective.h"
 
-using vrxperience_bridge::SimDataSender;
-typedef SimDataSender<vrxperience_msgs::msg::CabToSteeringCorrective,
-    IndyDS_CabToSteeringCorrective> CabToSteeringCorrectiveSender;
-
-void convert(
-  vrxperience_msgs::msg::CabToSteeringCorrective IN rosMsg,
-  IndyDS_CabToSteeringCorrective OUT simMsg)
+namespace vrxperience_bridge
 {
-  simMsg.TimeOfUpdate = rosMsg.header.stamp.sec + rosMsg.header.stamp.nanosec * 1e-9;
-  simMsg.AdditiveSteeringWheelAngle = rosMsg.additive_steering_wheel_angle;
-  simMsg.MultiplicativeSteeringWheelAngle = rosMsg.multiplicative_steering_wheel_angle;
-  simMsg.AdditiveSteeringWheelSpeed = rosMsg.additive_steering_wheel_speed;
-  simMsg.MultiplicativeSteeringWheelSpeed = rosMsg.additive_steering_wheel_speed;
-  simMsg.AdditiveSteeringWheelAccel = rosMsg.additive_steering_wheel_accel;
-  simMsg.MultiplicativeSteeringWheelAccel = rosMsg.multiplicative_steering_wheel_accel;
-  simMsg.AdditiveSteeringWheelTorque = rosMsg.additive_steering_wheel_torque;
-  simMsg.MultiplicativeSteeringWheelTorque = rosMsg.multiplicative_steering_wheel_torque;
-}
 
-int main(int argc, char * argv[])
+class CabToSteeringCorrectiveSender
+  : public SimDataSender<vrxperience_msgs::msg::CabToSteeringCorrective,
+    IndyDS_CabToSteeringCorrective>
 {
-  rclcpp::init(argc, argv);
-  auto sender = std::make_shared<CabToSteeringCorrectiveSender>(
-    "send_cab_to_steering_corrective",
-    IndyDS_CabToSteeringCorrective_desc,
-    &convert);
+public:
+  explicit CabToSteeringCorrectiveSender(const rclcpp::NodeOptions & options)
+  : SimDataSender(
+      "send_cab_to_steering_corrective",
+      options,
+      IndyDS_CabToSteeringCorrective_desc,
+      std::bind(&CabToSteeringCorrectiveSender::convert, this, _1, _2)
+  )
+  {
+  }
 
-  rclcpp::spin(sender);
-}
+  void convert(
+    vrxperience_msgs::msg::CabToSteeringCorrective IN rosMsg,
+    IndyDS_CabToSteeringCorrective OUT simMsg)
+  {
+    simMsg.TimeOfUpdate = rosMsg.header.stamp.sec + rosMsg.header.stamp.nanosec * 1e-9;
+    simMsg.AdditiveSteeringWheelAngle = rosMsg.additive_steering_wheel_angle;
+    simMsg.MultiplicativeSteeringWheelAngle = rosMsg.multiplicative_steering_wheel_angle;
+    simMsg.AdditiveSteeringWheelSpeed = rosMsg.additive_steering_wheel_speed;
+    simMsg.MultiplicativeSteeringWheelSpeed = rosMsg.additive_steering_wheel_speed;
+    simMsg.AdditiveSteeringWheelAccel = rosMsg.additive_steering_wheel_accel;
+    simMsg.MultiplicativeSteeringWheelAccel = rosMsg.multiplicative_steering_wheel_accel;
+    simMsg.AdditiveSteeringWheelTorque = rosMsg.additive_steering_wheel_torque;
+    simMsg.MultiplicativeSteeringWheelTorque = rosMsg.multiplicative_steering_wheel_torque;
+  }
+};  // class CabToSteeringCorrectiveSender
+
+}  // namespace vrxperience_bridge
+
+#include <rclcpp_components/register_node_macro.hpp>  // NOLINT
+RCLCPP_COMPONENTS_REGISTER_NODE(vrxperience_bridge::CabToSteeringCorrectiveSender)

--- a/vrxperience_bridge/src/send_dds_done_reply.cpp
+++ b/vrxperience_bridge/src/send_dds_done_reply.cpp
@@ -35,7 +35,7 @@ public:
   {
   }
 
-  void convert(std_msgs::msg::ByteMultiArray IN rosMsg, DDS_Octets OUT simMsg)
+  void convert(const std_msgs::msg::ByteMultiArray & rosMsg, DDS_Octets & simMsg)
   {
     UNUSED(rosMsg);
 

--- a/vrxperience_bridge/src/send_dds_done_reply.cpp
+++ b/vrxperience_bridge/src/send_dds_done_reply.cpp
@@ -12,35 +12,42 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <memory>
-
 #include "vrxperience_bridge/sim_data_sender.hpp"
 #include "std_msgs/msg/byte_multi_array.hpp"
 #include "DDS_Octets.h"
 
 #define UNUSED(x) (void)(x)
 
-using vrxperience_bridge::SimDataSender;
-typedef SimDataSender<std_msgs::msg::ByteMultiArray, DDS_Octets> DDSDoneReplySender;
-
-void convert(std_msgs::msg::ByteMultiArray IN rosMsg, DDS_Octets OUT simMsg)
+namespace vrxperience_bridge
 {
-  UNUSED(rosMsg);
 
-  // TODO(goldob) Copy data before sending out the message
-  simMsg.value._length = 0;
-  simMsg.value._buffer = nullptr;
-  simMsg.value._release = true;
-  simMsg.value._maximum = 0;
-}
-
-int main(int argc, char * argv[])
+class DdsDoneReplySender
+  : public SimDataSender<std_msgs::msg::ByteMultiArray, DDS_Octets>
 {
-  rclcpp::init(argc, argv);
-  auto sender = std::make_shared<DDSDoneReplySender>(
-    "send_dds_done_reply",
-    DDS_Octets_desc,
-    &convert);
+public:
+  explicit DdsDoneReplySender(const rclcpp::NodeOptions & options)
+  : SimDataSender(
+      "send_dds_done_reply",
+      options,
+      DDS_Octets_desc,
+      std::bind(&DdsDoneReplySender::convert, this, _1, _2)
+  )
+  {
+  }
 
-  rclcpp::spin(sender);
-}
+  void convert(std_msgs::msg::ByteMultiArray IN rosMsg, DDS_Octets OUT simMsg)
+  {
+    UNUSED(rosMsg);
+
+    // TODO(goldob) Copy data before sending out the message
+    simMsg.value._length = 0;
+    simMsg.value._buffer = nullptr;
+    simMsg.value._release = true;
+    simMsg.value._maximum = 0;
+  }
+};  // class DdsDoneReplySender
+
+}  // namespace vrxperience_bridge
+
+#include <rclcpp_components/register_node_macro.hpp>  // NOLINT
+RCLCPP_COMPONENTS_REGISTER_NODE(vrxperience_bridge::DdsDoneReplySender)


### PR DESCRIPTION
Depends on #4 

This PR does the following:
- Converts each stand-alone node into a `class` and a Component
- Moves some common `using` statements and global variables into the receiver and sender base classes
- Replaces the preprocessor macro for the convert functions with a `std::function`